### PR TITLE
Correct type field binding in StatCard

### DIFF
--- a/src/bindings/StatCard.res
+++ b/src/bindings/StatCard.res
@@ -21,7 +21,7 @@ type chartDataPoint = {
 // Structure for representing change values
 type statCardChange = {
   value: float,
-  type_: changeType,
+  @as("type") type_: changeType,
 }
 
 // StatCard component props


### PR DESCRIPTION

Replaced the internal field name type_ with the correctly annotated ReScript binding:
<pre>
@as("type") type_: changeType
</pre>


---
**Why**:

ReScript reserves type as a keyword, so we use type_ internally. However, without @as("type"), the generated JavaScript uses the wrong key (type_ instead of type), breaking interop with expected JS/TS objects or props.


---
**Impact**:

Fixes incorrect serialization of statCardChange records when passed to JS consumers or rendered components. Ensures the field type is emitted correctly in JS output.


